### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Pull Requests
 We actively welcome your pull requests.
 


### PR DESCRIPTION
In the past there was not info and support to add these docs to all Facebook Open Source projects. It's a useful measure that we can take now to create a healthy, welcoming open source community. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Delegated Recovery community profile](https://github.com/facebook/DelegatedRecoverySpecification/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1492" alt="screen shot 2018-01-14 at 3 22 32 pm" src="https://user-images.githubusercontent.com/1114467/34922025-095020a0-f93f-11e7-969f-c65d99c26ab2.png">
<img width="1497" alt="screen shot 2018-01-14 at 3 22 42 pm" src="https://user-images.githubusercontent.com/1114467/34922026-0970ac6c-f93f-11e7-90b5-317a8f342c59.png">

**issue:**
internal task t23481323